### PR TITLE
don't call FETCH_SUCCESS on error

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -24,16 +24,20 @@ export default store => {
 
         rpc
           .call(action.name, args)
-          .then(result =>
-            store.dispatch(
-              actions.fetchSuccess({
-                name: action.name,
-                args,
-                id,
-                result,
-              }),
-            ),
-          )
+          .then(result => {
+            console.log(result)
+
+            if (result) {
+              store.dispatch(
+                actions.fetchSuccess({
+                  name: action.name,
+                  args,
+                  id,
+                  result,
+                }),
+              )
+            }
+          })
           .catch(error => {
             console.error(error) // eslint-disable-line
             store.dispatch(

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -141,4 +141,31 @@ describe('middleware', () => {
       error: RPCClient.fakeError,
     })
   })
+  it('should not dispatch a FETCH_SUCCESS action on error', async () => {
+    const store = {
+      dispatch: jest.fn(),
+      getState: () => ({
+        asyncDataFetch: {},
+      }),
+    }
+    const name = 'fail'
+    const args = {
+      test: 'yes',
+    }
+    const action = {
+      type: actionTypes.FETCH,
+      name,
+      args,
+    }
+    middleware(store)(() => {})(action)
+    await sleep() // give the event loop a chance to process promise
+    expect(store.dispatch).toHaveBeenCalledTimes(2)
+    expect(store.dispatch).toHaveBeenLastCalledWith({
+      type: `${name}_${actionTypes.FETCH_FAIL}`,
+      name,
+      args,
+      id: 0,
+      error: RPCClient.fakeError,
+    })
+  })
 })


### PR DESCRIPTION
This is needed so that in case of errors we can handle it in the `FETCH_FAIL` handler, without worrying about protecting the `FETCH_SUCCESS` logic from missing or malformed data.

This is needed to properly handle RPC errors in the front-end in https://github.com/bufferapp/buffer-analyze/pull/337

Hey @djfarrelly and @msanroman, would love your eyes on this one, not sure if I'm missing any cases where we want to trigger`FETCH_SUCESS` in case of errors. 